### PR TITLE
Add french translation

### DIFF
--- a/hot_rock.lua
+++ b/hot_rock.lua
@@ -15,7 +15,7 @@ simple_copy = function(t)
 	return r
 end
 
-magma_conduits.make_hot_node_def = function(name, original_def)
+magma_conduits.make_hot_node_def = function(name, original_def, description)
 	original_def.groups = original_def.groups or {}
 	local hot_node_def = simple_copy(original_def)
 
@@ -26,7 +26,7 @@ magma_conduits.make_hot_node_def = function(name, original_def)
 	hot_node_def.groups.lava_heated = 1
 	hot_node_def.groups.not_in_creative_inventory = 1
 	hot_node_def._magma_conduits_cools_to = name
-	hot_node_def.description = S("Hot @1", hot_node_def.description)
+	hot_node_def.description = description or S("Hot @1", hot_node_def.description)
 	
 	for k, v in ipairs(hot_node_def.tiles) do
 		hot_node_def.tiles[k] = v .. "^magma_conduits_lava_overlay.png"

--- a/locale/magma_conduits.fr.tr
+++ b/locale/magma_conduits.fr.tr
@@ -1,0 +1,25 @@
+# textdomain: magma_conduits
+
+
+### hot_rock.lua ###
+
+Hot @1=@1 chaude
+Hot Cobble=Pierre chaude
+Hot Obsidian=Obsidienne chaude
+Hot stone riven with cracks and seeping traces of lava.=Pierre chaude rongée par des fissures et des traces de laves.
+Obsidian heated to a dull red glow.=Obsidienne chaude émettant une lueur rouge terne.
+
+When normal obsidian is heated by lava it is converted into this. Beware when digging here!=Lorsque de l’obsidienne est chauffée par la lave, elle se transforme en ce bloc. Prenez garde en le minant !
+
+When normal stone is heated by lava it is converted into this. Beware when digging here!=Lorsque de la pierre est chauffée par la lave, elle se transforme en ce bloc. Prenez garde en le minant !
+
+
+### volcanoes.lua ###
+
+Allows players to use a console command to find volcanoes=Permet au joueurs d’utiliser une commande pour trouver les volcans.
+No volcanoes near @1=Pas de volcan près de @1.
+You need the findvolcano privilege to use this command.=Le privilège findvolcano est nécessaire pour utiliser cette commande.
+a volcano=un volcan
+
+find the volcanoes near the player's map region, or in the map region containing pos if provided=trouve les volcans proches de la zone du joueur, ou proche de la zone contenant les coordonnées si elles sont fournies
+


### PR DESCRIPTION
Also adds ability to provide translation in `make_hot_node_def` api because in
some languages, `Hot @1` translation may varies depending on values of
`@1` (example, in french `Hot stone` -> `Roche chaude`, `Hot sand` ->
`Sable chaud` (no `e` at the end)).